### PR TITLE
[FEATURE] Adding "lr" parameter from google API as extension configuration option.

### DIFF
--- a/Classes/Configuration/ExtConf.php
+++ b/Classes/Configuration/ExtConf.php
@@ -34,6 +34,11 @@ class ExtConf implements SingletonInterface
     /**
      * @var bool
      */
+    protected $filterByCurrentLang = false;
+
+    /**
+     * @var bool
+     */
     protected $enableCache = true;
 
     /**
@@ -44,7 +49,7 @@ class ExtConf implements SingletonInterface
     /**
      * @var array
      */
-    protected $requiredSettings = ['googleApiKey' => true, 'googleCseKey' => true];
+    protected $requiredSettings = ['googleApiKey' => true, 'googleCseKey' => true, 'filterByCurrentLang' => false];
 
     /**
      * ExtConf constructor.
@@ -98,6 +103,16 @@ class ExtConf implements SingletonInterface
     public function setGoogleCseKey(string $googleCseKey): void
     {
         $this->googleCseKey = $googleCseKey;
+    }
+
+    public function getFilterByCurrentLang(): bool
+    {
+        return $this->filterByCurrentLang;
+    }
+
+    public function setFilterByCurrentLang(bool $filterByCurrentLang): void
+    {
+        $this->filterByCurrentLang = $filterByCurrentLang;
     }
 
     public function isEnableCache(): bool

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -2,6 +2,8 @@
 googleApiKey =
 # cat=basic; type=string; label = Google Custom Search Enginge Key: Get your own on https://cse.google.com/cse/
 googleCseKey =
+# cat=basic; type=boolean; label = If true the results will be filtered by the current selected language in frontend.
+filterByCurrentLang = 0
 # cat=basic; type=boolean; label=Enable cache for search results
 enableCache = 1
 # cat=basic; type=int; label=Lifetime of search result cache entries (in seconds):Default = 300 (5 minutes)


### PR DESCRIPTION
There is a boolean on the extension configuration for enabling results just on the frontend selected language in Typo3.

# cat=basic; type=boolean; label = If true the results will be filtered by the current selected language in frontend.
filterByCurrentLang = 0

If "true" it will add to the URL the "lr" parameter from Google's API so the results returned are just in the language selected in the frontend.